### PR TITLE
Fix Partial Program Crash BUG

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -813,6 +813,7 @@ class DownloadTrainersThread(DownloadBaseThread):
 
         # Locate extracted .exe file
         cnt = 0
+        gameRawName = None
         for filename in os.listdir(self.tempDir):
             if "Trainer" in filename and filename.endswith(".exe"):
                 gameRawName = filename


### PR DESCRIPTION
Fixed a bug that caused the game to crash when downloading certain modifiers.

Corresponding error message:
UnboundLocalError: local variable 'gameRawName' referenced before assignment