### PR TITLE
Fix Partial Program Crash BUG

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -824,6 +824,12 @@ class DownloadTrainersThread(DownloadBaseThread):
             self.messageBox.emit("info", tr("Attention"), tr("Additional actions required\nPlease check folder for details!"))
             os.startfile(self.tempDir)
 
+        # Check if gameRawName is None
+        if gameRawName is None:
+            self.messageBox.emit("error", tr("Error"), tr("Could not find the downloaded trainer file, please try turning your antivirus software off."))
+            self.finished.emit(1)
+            return
+
         os.makedirs(self.trainerPath, exist_ok=True)
         trainer_name = trans_mFilename + ".exe"
         source_file = os.path.join(self.tempDir, gameRawName)

--- a/helper.py
+++ b/helper.py
@@ -813,6 +813,7 @@ class DownloadTrainersThread(DownloadBaseThread):
 
         # Locate extracted .exe file
         cnt = 0
+        gameRawName = None
         for filename in os.listdir(self.tempDir):
             if "Trainer" in filename and filename.endswith(".exe"):
                 gameRawName = filename


### PR DESCRIPTION
Fixed a bug that caused the game to crash when downloading certain modifiers.

Corresponding error message:
UnboundLocalError: local variable 'gameRawName' referenced before assignment