### PR TITLE
Add theme-aware custom title bar

### DIFF
--- a/src/scripts/main.py
+++ b/src/scripts/main.py
@@ -11,7 +11,7 @@ import tempfile
 import webbrowser
 import winreg
 
-from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtCore import QEvent, Qt, QTimer
 from PyQt6.QtGui import QAction, QColor, QFont, QFontDatabase, QIcon, QPainter, QPixmap
 from PyQt6.QtWidgets import QApplication, QFileDialog, QGridLayout, QHBoxLayout, QLabel, QLineEdit, QListWidgetItem, QMainWindow, QMessageBox, QStatusBar, QVBoxLayout, QWidget
 from tendo import singleton
@@ -32,6 +32,7 @@ class GameCheatsManager(QMainWindow):
 
     def __init__(self):
         super().__init__()
+        self.setWindowFlag(Qt.WindowType.FramelessWindowHint, True)
 
         # Single instance check and basic UI setup
         try:
@@ -141,6 +142,7 @@ class GameCheatsManager(QMainWindow):
         browseAllTrainersAction = QAction(tr("Browse All Trainers"), self)
         browseAllTrainersAction.triggered.connect(self.browse_all_trainers)
         menu.addAction(browseAllTrainersAction)
+        self.setup_window_chrome(menu)
 
         # Status bar setup
         self.statusbar = QStatusBar()
@@ -280,6 +282,23 @@ class GameCheatsManager(QMainWindow):
     # ===========================================================================
     # Core functions
     # ===========================================================================
+    def setup_window_chrome(self, menu):
+        chrome = QWidget(self)
+        chrome.setObjectName("WindowChrome")
+        chromeLayout = QVBoxLayout(chrome)
+        chromeLayout.setContentsMargins(0, 0, 0, 0)
+        chromeLayout.setSpacing(0)
+
+        self.titleBar = WindowTitleBar(self)
+        chromeLayout.addWidget(self.titleBar)
+        chromeLayout.addWidget(menu)
+        self.setMenuWidget(chrome)
+
+    def changeEvent(self, event):
+        super().changeEvent(event)
+        if event.type() == QEvent.Type.WindowStateChange and hasattr(self, "titleBar"):
+            self.titleBar.sync_window_state()
+
     def closeEvent(self, event):
         self.cleanup_launch_junctions()
         super().closeEvent(event)

--- a/src/scripts/style_sheet.py
+++ b/src/scripts/style_sheet.py
@@ -3,18 +3,60 @@ white = """
         background-color: #ffffff;
     }}
 
+    QWidget#WindowChrome,
+    QWidget#WindowTitleBar {{
+        background-color: #ffffff;
+    }}
+
+    QWidget#WindowChrome {{
+        border-bottom: 1px solid #dddddd;
+    }}
+
+    QLabel#WindowTitleText {{
+        color: #000000;
+    }}
+
+    QPushButton#WindowTitleButton,
+    QPushButton#WindowCloseButton {{
+        border: none;
+        border-radius: 0px;
+        background-color: transparent;
+        color: #000000;
+        padding: 0px;
+        font-weight: normal;
+        outline: none;
+    }}
+
+    QPushButton#WindowTitleButton:hover {{
+        background-color: #e6e6e6;
+    }}
+
+    QPushButton#WindowTitleButton:pressed {{
+        background-color: #d9d9d9;
+    }}
+
+    QPushButton#WindowCloseButton:hover {{
+        background-color: #c42b1c;
+        color: #ffffff;
+    }}
+
+    QPushButton#WindowCloseButton:pressed {{
+        background-color: #a3261b;
+        color: #ffffff;
+    }}
+
     QStatusBar::item {{
         border: none;
     }}
 
     QMenuBar {{
-        background-color: #f9f9f9;
+        background-color: #ffffff;
     }}
 
     QMenuBar::item {{
-        background-color: #f9f9f9;
+        background-color: #ffffff;
         color: #000000;
-        padding: 5px;
+        padding: 6px 8px;
     }}
 
     QMenuBar::item:selected {{
@@ -287,37 +329,80 @@ black = """
         background-color: #1c1c1c;
     }}
 
+    QWidget#WindowChrome,
+    QWidget#WindowTitleBar {{
+        background-color: #1c1c1c;
+    }}
+
+    QWidget#WindowChrome {{
+        border-bottom: 1px solid #2f2f2f;
+    }}
+
+    QLabel#WindowTitleText {{
+        color: #ffffff;
+    }}
+
+    QPushButton#WindowTitleButton,
+    QPushButton#WindowCloseButton {{
+        border: none;
+        border-radius: 0px;
+        background-color: transparent;
+        color: #ffffff;
+        padding: 0px;
+        font-weight: normal;
+        outline: none;
+    }}
+
+    QPushButton#WindowTitleButton:hover {{
+        background-color: #2a2a2a;
+    }}
+
+    QPushButton#WindowTitleButton:pressed {{
+        background-color: #242424;
+    }}
+
+    QPushButton#WindowCloseButton:hover {{
+        background-color: #c42b1c;
+        color: #ffffff;
+    }}
+
+    QPushButton#WindowCloseButton:pressed {{
+        background-color: #a3261b;
+        color: #ffffff;
+    }}
+
     QStatusBar::item {{
         border: none;
     }}
 
     QMenuBar {{
-        background-color: #2e2e2e;
+        background-color: #1c1c1c;
     }}
 
     QMenuBar::item {{
-        background-color: #2e2e2e;
+        background-color: #1c1c1c;
         color: #FFFFFF;
-        padding: 5px;
+        padding: 6px 8px;
     }}
 
     QMenuBar::item:selected {{
-        background-color: #484848;
+        background-color: #2a2a2a;
     }}
 
     QMenu {{
         background-color: #1c1c1c;
-        border: 2px solid #ffffff;
+        border: 1px solid #3a3a3a;
         border-radius: 5px;
     }}
 
     QMenu::item {{
         background-color: #1c1c1c;
         color: #FFFFFF;
+        padding: 6px 24px 6px 12px;
     }}
 
     QMenu::item:selected {{
-        background-color: #484848;
+        background-color: #2a2a2a;
     }}
 
     QStatusBar {{

--- a/src/scripts/widgets/custom_dialogs.py
+++ b/src/scripts/widgets/custom_dialogs.py
@@ -7,7 +7,7 @@ from PyQt6.QtGui import QIcon, QPixmap
 from PyQt6.QtWidgets import QCheckBox, QComboBox, QDialog, QFileDialog, QHBoxLayout, QLabel, QLineEdit, QMessageBox, QProgressBar, QSizePolicy, QTextEdit, QVBoxLayout
 
 from config import *
-from widgets.custom_widgets import CustomButton
+from widgets.custom_widgets import CustomButton, apply_native_title_bar_theme
 from threads.other_threads import VersionFetchWorker, TrainerUploadWorker
 
 
@@ -18,6 +18,7 @@ class AnnouncementDialog(QDialog):
 
         self.setWindowTitle(tr("Announcement"))
         self.setWindowIcon(QIcon(resource_path("assets/logo.ico")))
+        apply_native_title_bar_theme(self)
         self.setMinimumWidth(850)
 
         layout = QVBoxLayout()
@@ -82,6 +83,7 @@ class CopyRightWarning(QDialog):
         super().__init__(parent)
         self.setWindowTitle(tr("Warning"))
         self.setWindowIcon(QIcon(resource_path("assets/logo.ico")))
+        apply_native_title_bar_theme(self)
         layout = QVBoxLayout()
         layout.setSpacing(30)
         layout.setContentsMargins(20, 30, 20, 20)
@@ -151,6 +153,7 @@ class SettingsDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle(tr("Settings"))
         self.setWindowIcon(QIcon(resource_path("assets/setting.ico")))
+        apply_native_title_bar_theme(self)
         settingsLayout = QVBoxLayout()
         settingsLayout.setSpacing(15)
         self.setLayout(settingsLayout)
@@ -295,6 +298,7 @@ class AboutDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle(tr("About"))
         self.setWindowIcon(QIcon(resource_path("assets/logo.ico")))
+        apply_native_title_bar_theme(self)
         aboutLayout = QVBoxLayout()
         aboutLayout.setSpacing(30)
         aboutLayout.setContentsMargins(40, 20, 40, 30)
@@ -431,6 +435,7 @@ class TrainerUploadDialog(QDialog):
         self.worker = None
         self.setWindowTitle(tr("Upload Trainer"))
         self.setWindowIcon(QIcon(resource_path("assets/logo.ico")))
+        apply_native_title_bar_theme(self)
         self.setMinimumWidth(500)
 
         layout = QVBoxLayout()

--- a/src/scripts/widgets/custom_widgets.py
+++ b/src/scripts/widgets/custom_widgets.py
@@ -1,9 +1,122 @@
+import ctypes
+import sys
+
 from PyQt6.QtCore import QEasingCurve, QPropertyAnimation, QRect, QRectF, Qt, QTimer, pyqtSignal
 from PyQt6.QtGui import QColor, QFont, QFontDatabase, QPainter, QPainterPath, QPen, QPixmap
 from PyQt6.QtWidgets import QApplication, QFrame, QGraphicsDropShadowEffect, QHBoxLayout, QLabel, QListWidget, QListWidgetItem, QProxyStyle, QPushButton, QSizePolicy, QStyle, QVBoxLayout, QWidget
 from zhon.cedict import simp, trad
 
 from config import *
+
+
+def apply_native_title_bar_theme(window):
+    if sys.platform != "win32":
+        return
+
+    try:
+        hwnd = int(window.winId())
+        use_dark = ctypes.c_int(1 if settings.get("theme", "dark") == "dark" else 0)
+        # DWMWA_USE_IMMERSIVE_DARK_MODE is 20 on current Windows builds and
+        # 19 on older Windows 10 builds that first exposed the attribute.
+        for attribute in (20, 19):
+            ctypes.windll.dwmapi.DwmSetWindowAttribute(
+                hwnd,
+                attribute,
+                ctypes.byref(use_dark),
+                ctypes.sizeof(use_dark),
+            )
+    except Exception:
+        pass
+
+
+class WindowTitleBar(QWidget):
+    def __init__(self, window):
+        super().__init__(window)
+        self.window = window
+        self._drag_pos = None
+        self.setObjectName("WindowTitleBar")
+        self.setFixedHeight(34)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(10, 0, 0, 0)
+        layout.setSpacing(8)
+
+        self.iconLabel = QLabel()
+        self.iconLabel.setFixedSize(18, 18)
+        self.iconLabel.setPixmap(window.windowIcon().pixmap(16, 16))
+        layout.addWidget(self.iconLabel)
+
+        self.titleLabel = QLabel(window.windowTitle())
+        self.titleLabel.setObjectName("WindowTitleText")
+        self.titleLabel.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        layout.addWidget(self.titleLabel)
+
+        self.minimizeButton = self._create_button("−", "Minimize")
+        self.maximizeButton = self._create_button("□", "Maximize")
+        self.closeButton = self._create_button("×", "Close")
+        self.closeButton.setObjectName("WindowCloseButton")
+
+        layout.addWidget(self.minimizeButton)
+        layout.addWidget(self.maximizeButton)
+        layout.addWidget(self.closeButton)
+
+        self.minimizeButton.clicked.connect(window.showMinimized)
+        self.maximizeButton.clicked.connect(self.toggle_maximized)
+        self.closeButton.clicked.connect(window.close)
+        window.windowTitleChanged.connect(self.titleLabel.setText)
+
+    def _create_button(self, text, tooltip):
+        button = QPushButton(text)
+        button.setObjectName("WindowTitleButton")
+        button.setToolTip(tooltip)
+        button.setFixedSize(46, 34)
+        button.setCursor(Qt.CursorShape.PointingHandCursor)
+        button.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        return button
+
+    def toggle_maximized(self):
+        if self.window.isMaximized():
+            self.window.showNormal()
+        else:
+            self.window.showMaximized()
+        self.sync_window_state()
+
+    def sync_window_state(self):
+        if self.window.isMaximized():
+            self.maximizeButton.setText("❐")
+            self.maximizeButton.setToolTip("Restore")
+        else:
+            self.maximizeButton.setText("□")
+            self.maximizeButton.setToolTip("Maximize")
+
+    def mouseDoubleClickEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.toggle_maximized()
+            event.accept()
+            return
+        super().mouseDoubleClickEvent(event)
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            handle = self.window.windowHandle()
+            if handle and handle.startSystemMove():
+                event.accept()
+                return
+            self._drag_pos = event.globalPosition().toPoint() - self.window.frameGeometry().topLeft()
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):
+        if self._drag_pos and event.buttons() & Qt.MouseButton.LeftButton and not self.window.isMaximized():
+            self.window.move(event.globalPosition().toPoint() - self._drag_pos)
+            event.accept()
+            return
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event):
+        self._drag_pos = None
+        super().mouseReleaseEvent(event)
 
 
 class LargerActionIconStyle(QProxyStyle):

--- a/src/scripts/widgets/trainer_management.py
+++ b/src/scripts/widgets/trainer_management.py
@@ -7,7 +7,7 @@ from PyQt6.QtGui import QIcon, QPixmap
 from PyQt6.QtCore import Qt, QTimer
 
 from config import *
-from widgets.custom_widgets import AlertWidget, CustomButton
+from widgets.custom_widgets import AlertWidget, CustomButton, apply_native_title_bar_theme
 from threads.other_threads import WeModCustomization
 
 
@@ -16,6 +16,7 @@ class TrainerManagementDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle(tr("Trainer Management"))
         self.setWindowIcon(QIcon(resource_path("assets/logo.ico")))
+        apply_native_title_bar_theme(self)
         self.setMinimumWidth(650)
         self.active_alerts = []
 


### PR DESCRIPTION
你好，感谢你的app

我在使用过程中发现深色模式中，Windows 原生标题栏还是白色的，是系统标题栏，并没有跟随深色模式变动，于是做出一些修改：

- 顶部加入自绘标题栏 + 原菜单栏组合
- 支持图标、标题、最小化、最大化/还原、关闭
- 支持拖动窗口、双击最大化
- 为自绘标题栏补了深色/浅色样式
- 菜单栏也同步为对应主题色

这是原深色模式：
<img width="702" height="552" alt="image" src="https://github.com/user-attachments/assets/88d5009e-e4ab-4d6b-b45d-db3e61b41ac9" />

这是修改后深色模式和浅色模式：
<img width="430" height="320" alt="image" src="https://github.com/user-attachments/assets/0c2ebcdd-eec2-482b-9c1e-4cf2d3b080e6" />
<img width="436" height="322" alt="image" src="https://github.com/user-attachments/assets/8d69fd97-927d-46b9-93bc-ae26728056c7" />
